### PR TITLE
Use binary file read/write for marshalling

### DIFF
--- a/lib/diskcached.rb
+++ b/lib/diskcached.rb
@@ -149,7 +149,7 @@ class Diskcached
   private
   # creates the actual cache file
   def write_cache_file key, content
-    f = File.open( cache_file(key), "w+" )
+    f = File.open( cache_file(key), "wb+" )
     f.flock(File::LOCK_EX)
     f.write( content )
     f.close
@@ -158,7 +158,7 @@ class Diskcached
 
   # reads the actual cache file
   def read_cache_file key
-    f = File.open( cache_file(key), "r" )
+    f = File.open( cache_file(key), "rb" )
     f.flock(File::LOCK_SH)
     out = f.read
     f.close


### PR DESCRIPTION
I have used diskcached (with joy) for many years but only now stumbled upon an issue where a serialized hash can't be read again. Looking into the code I found that diskcached doesn't use binary file mode. I believe this is an error and bound to cause issues with newlines (\r\n vs. \r vs. \n) at least under Windows.

Could you merge my pull request?